### PR TITLE
add upwardPreference and downwardPreference in PullDownMenuPosition.

### DIFF
--- a/lib/src/_internals/route_layout.dart
+++ b/lib/src/_internals/route_layout.dart
@@ -32,10 +32,12 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
     final height = switch (menuPosition) {
       PullDownMenuPosition.over when check => buttonRect.bottom - padding.top,
       PullDownMenuPosition.over =>
-        constraintsHeight - buttonRect.top - padding.bottom,
+      constraintsHeight - buttonRect.top - padding.bottom,
       PullDownMenuPosition.automatic when check => buttonRect.top - padding.top,
       PullDownMenuPosition.automatic =>
-        constraintsHeight - buttonRect.bottom - padding.bottom,
+      constraintsHeight - buttonRect.bottom - padding.bottom,
+      PullDownMenuPosition.upwardPreference => constraintsHeight,
+      PullDownMenuPosition.downwardPreference => constraintsHeight,
     };
 
     return BoxConstraints.loose(
@@ -122,14 +124,23 @@ abstract class _PositionUtils {
           y -= childHeight - buttonHeight;
         }
       case PullDownMenuPosition.automatic:
-        // Native variant applies additional 5px of padding to menu if
-        // [buttonHeight] is smaller than 44px.
+      case PullDownMenuPosition.upwardPreference:
+      case PullDownMenuPosition.downwardPreference:
+      // Native variant applies additional 5px of padding to menu if
+      // [buttonHeight] is smaller than 44px.
         final padding =
-            buttonHeight < kMinInteractiveDimensionCupertino ? 5 : 0;
-
-        isInBottomHalf
-            ? y -= childHeight + padding
-            : y += buttonHeight + padding;
+        buttonHeight < kMinInteractiveDimensionCupertino ? 5 : 0;
+        if (menuPosition == PullDownMenuPosition.upwardPreference &&
+            childHeight + padding < y) {
+          y -= childHeight + padding;
+        } else if (menuPosition == PullDownMenuPosition.downwardPreference &&
+            childHeight + padding < screen.height - y) {
+          y += buttonHeight + padding;
+        } else {
+          isInBottomHalf
+              ? y -= childHeight + padding
+              : y += buttonHeight + padding;
+        }
     }
 
     return y;

--- a/lib/src/_internals/route_layout.dart
+++ b/lib/src/_internals/route_layout.dart
@@ -36,8 +36,9 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
       PullDownMenuPosition.automatic when check => buttonRect.top - padding.top,
       PullDownMenuPosition.automatic =>
       constraintsHeight - buttonRect.bottom - padding.bottom,
-      PullDownMenuPosition.upwardPreference => constraintsHeight,
-      PullDownMenuPosition.downwardPreference => constraintsHeight,
+      PullDownMenuPosition.upwardPreference =>
+      constraintsHeight - buttonRect.bottom - padding.bottom,
+      PullDownMenuPosition.downwardPreference => buttonRect.top - padding.top,
     };
 
     return BoxConstraints.loose(

--- a/lib/src/pull_down_button.dart
+++ b/lib/src/pull_down_button.dart
@@ -25,6 +25,18 @@ enum PullDownMenuPosition {
   /// if positioned above - upwards movement will be used.
   automatic,
 
+  /// Similar to [automatic], but with an upward preference:
+  /// If there's enough space above to display the menu, it will display upwards
+  /// even when the anchor is in the upper half of the screen.
+  upwardPreference,
+
+
+  /// Similar to [automatic], but with a downward preference:
+  /// If there's enough space below to display the menu, it will display downwards
+  /// even when the anchor is in the lower half of the screen.
+  downwardPreference,
+
+
   /// Menu is positioned under or above an anchor depending on the side that
   /// has more space available but also covers the button used to open the menu.
   ///
@@ -502,6 +514,7 @@ Future<void> showPullDownMenu({
   required List<PullDownMenuEntry> items,
   required Rect position,
   PullDownMenuItemsOrder itemsOrder = PullDownMenuItemsOrder.downwards,
+  PullDownMenuPosition menuPosition = PullDownMenuPosition.automatic,
   double menuOffset = 16,
   ScrollController? scrollController,
   PullDownMenuCanceled? onCanceled,
@@ -517,7 +530,7 @@ Future<void> showPullDownMenu({
     context: context,
     items: items,
     buttonRect: position,
-    menuPosition: PullDownMenuPosition.automatic,
+    menuPosition: menuPosition,
     itemsOrder: itemsOrder,
     routeTheme: routeTheme,
     hasLeading: hasLeading,


### PR DESCRIPTION
When the button is in the lower half of the screen and there's sufficient space below it to display the popup menu, use [downwardPreference] to position the menu below the button. The same logic applies to [upwardPreference].