### PR TITLE
Update deprecated color properties for transparency checks

### DIFF
--- a/lib/src/_internals/blur.dart
+++ b/lib/src/_internals/blur.dart
@@ -12,7 +12,7 @@ abstract final class BlurUtils {
   /// Returns false if [color] has no transparency. If so, [BackdropFilter] will
   /// not be used since it will be redundant. Also, in some cases, this might
   /// help with performance or visual bugs.
-  static bool useBackdropFilter(Color color) => color.alpha != 0xFF;
+  static bool useBackdropFilter(Color color) => color.a != 1.0;
 
   /// Menu background blur.
   ///

--- a/lib/src/_internals/route_menu.dart
+++ b/lib/src/_internals/route_menu.dart
@@ -48,7 +48,7 @@ class RoutePullDownMenu extends StatelessWidget {
       begin: BoxDecoration(
         boxShadow: [
           BoxShadow(
-            color: theme.shadow!.color.withOpacity(0),
+            color: theme.shadow!.color.withValues(alpha: 0),
             blurRadius: theme.shadow!.blurRadius,
             spreadRadius: theme.shadow!.spreadRadius,
           ),


### PR DESCRIPTION
### Summary:
This PR updates the deprecated color handling methods to improve compatibility with the latest code standards.

### Changes:
1. Replaced the usage of `color.alpha != 0xFF` with `color.a != 1.0` for checking if a color is fully transparent.
2. Replaced deprecated `withOpacity` method with `withValues(alpha: 0)` for better handling of color opacity.