### PR TITLE
Fix: menu positioning in CupertinoNavigationBar on Flutter 3.35.x

### DIFF
--- a/lib/src/internals/extensions.dart
+++ b/lib/src/internals/extensions.dart
@@ -17,10 +17,16 @@ extension RectExtension on BuildContext {
   ///
   /// If [Rect]'s height is bigger than the screen size, additionally normalize
   /// [Rect] to help mitigate possible layout issues.
-  Rect getRect({RenderObject? ancestor}) {
-    final RenderBox renderBoxContainer = currentRenderBox;
-    final MediaQueryData queryData = MediaQuery.of(this);
-    final Size size = queryData.size;
+  ///
+  /// The [mediaQueryContext] parameter can be provided to use a different
+  /// context for MediaQuery lookups. This is useful when the button's
+  /// context has incomplete MediaQuery data (e.g., Flutter 3.35.x nav bar
+  /// bug where MediaQueryData only contains textScaler).
+  Rect getRect({RenderObject? ancestor, BuildContext? mediaQueryContext}) {
+    final renderBoxContainer = currentRenderBox;
+    final queryContext = mediaQueryContext ?? this;
+    final queryData = MediaQuery.of(queryContext);
+    final size = queryData.size;
 
     final rect = Rect.fromPoints(
       renderBoxContainer.localToGlobal(
@@ -43,12 +49,8 @@ extension RectExtension on BuildContext {
 
 /// Apply some additional adjustments on [Rect] from [RectExtension.getRect] if
 /// [rect] is bigger than [size].
-Rect _normalizeLargeRect(
-  Rect rect,
-  Size size,
-  EdgeInsets padding,
-) {
-  const double minimumAllowedSize = kMinInteractiveDimensionCupertino * 2;
+Rect _normalizeLargeRect(Rect rect, Size size, EdgeInsets padding) {
+  const minimumAllowedSize = kMinInteractiveDimensionCupertino * 2;
 
   final bool topIsNegative = rect.top.isNegative;
   final double height = size.height;

--- a/lib/src/internals/route.dart
+++ b/lib/src/internals/route.dart
@@ -153,13 +153,20 @@ class PullDownMenuRoute<VoidCallback> extends PopupRoute<VoidCallback> {
 
   /// Attempt to predict an animation alignment for [RoutePullDownMenu] using
   /// a button's position.
+  ///
+  /// The [overlayContext] parameter can be provided to use a different context
+  /// for MediaQuery lookups. This is useful when the button's context has
+  /// incomplete MediaQuery data (e.g., Flutter 3.35.x CupertinoNavigationBar
+  /// bug where MediaQueryData only contains textScaler).
   static Alignment animationAlignment(
     BuildContext context,
-    Rect buttonRect,
-  ) {
-    final Offset buttonCenter = buttonRect.center;
+    Rect buttonRect, {
+    BuildContext? overlayContext,
+  }) {
+    final buttonCenter = buttonRect.center;
 
-    final Size size = MediaQuery.of(context).size;
+    final queryContext = overlayContext ?? context;
+    final size = MediaQuery.of(queryContext).size;
 
     final double heightCenter = size.height / 2;
 
@@ -199,12 +206,9 @@ enum _MenuHorizontalPosition {
 
   /// Returns a [_MenuHorizontalPosition] for provided screen [size] and a
   /// [buttonRect].
-  static _MenuHorizontalPosition get(
-    Size size,
-    Rect buttonRect,
-  ) {
-    final double leftPosition = buttonRect.left;
-    final double rightPosition = buttonRect.right;
+  static _MenuHorizontalPosition get(Size size, Rect buttonRect) {
+    final leftPosition = buttonRect.left;
+    final rightPosition = buttonRect.right;
 
     final double width = size.width;
     final double widthCenter = width / 2;

--- a/lib/src/pull_down_button.dart
+++ b/lib/src/pull_down_button.dart
@@ -160,19 +160,17 @@ typedef PullDownMenuCanceled = void Function();
 /// the button is pressed.
 ///
 /// Used by [PullDownButton.itemBuilder].
-typedef PullDownMenuItemBuilder =
-    List<Widget> Function(
-      BuildContext context,
-    );
+typedef PullDownMenuItemBuilder = List<PullDownMenuEntry> Function(
+    BuildContext context,
+);
 
 /// Signature used by [PullDownButton] to build button widget.
 ///
 /// Used by [PullDownButton.buttonBuilder].
-typedef PullDownMenuButtonBuilder =
-    Widget Function(
-      BuildContext context,
-      Future<void> Function() showMenu,
-    );
+typedef PullDownMenuButtonBuilder = Widget Function(
+    BuildContext context,
+    Future<void> Function() showMenu,
+);
 
 /// Signature used by [PullDownButton] to create animation for
 /// [PullDownButton.buttonBuilder] when the pull-down menu is opened.
@@ -391,16 +389,22 @@ class _PullDownButtonState extends State<PullDownButton> {
       rootNavigator: widget.useRootNavigator,
     );
 
-    final RenderBox overlay = navigator.overlay!.context.currentRenderBox;
-    Rect button = context.getRect(ancestor: overlay);
+    final overlay = navigator.overlay!.context.currentRenderBox;
+    var button = context.getRect(
+      ancestor: overlay,
+      mediaQueryContext: navigator.overlay!.context,
+    );
 
     if (widget.buttonAnchor != null) {
       button = _anchorToButtonPart(context, button, widget.buttonAnchor!);
     }
 
-    final Alignment animationAlignment =
-        widget.animationAlignmentOverride ??
-        PullDownMenuRoute.animationAlignment(context, button);
+    final animationAlignment = widget.animationAlignmentOverride ??
+        PullDownMenuRoute.animationAlignment(
+          context,
+          button,
+          overlayContext: navigator.overlay!.context,
+        );
 
     final List<Widget> items = widget.itemBuilder(context);
 
@@ -603,25 +607,24 @@ Rect _anchorToButtonPart(
     PullDownMenuAnchor.end => buttonRect.left,
   };
 
-  return Rect.fromLTRB(
-    side,
-    buttonRect.top,
-    side,
-    buttonRect.bottom,
-  );
+  return Rect.fromLTRB(side, buttonRect.top, side, buttonRect.bottom);
 }
 
 /// Returns a barrier label for [PullDownMenuRoute].
 String _barrierLabel(BuildContext context) {
   // Use this instead of `MaterialLocalizations.of(context)` because
   // [MaterialLocalizations] might be null in some cases.
-  final MaterialLocalizations? materialLocalizations =
-      Localizations.of<MaterialLocalizations>(context, MaterialLocalizations);
+  final materialLocalizations = Localizations.of<MaterialLocalizations>(
+    context,
+    MaterialLocalizations,
+  );
 
   // Use this instead of `CupertinoLocalizations.of(context)` because
   // [CupertinoLocalizations] might be null in some cases.
-  final CupertinoLocalizations? cupertinoLocalizations =
-      Localizations.of<CupertinoLocalizations>(context, CupertinoLocalizations);
+  final cupertinoLocalizations = Localizations.of<CupertinoLocalizations>(
+    context,
+    CupertinoLocalizations,
+  );
 
   // If both localizations are null, fallback to
   // [DefaultMaterialLocalizations().modalBarrierDismissLabel].


### PR DESCRIPTION
## Summary

Fixes menu positioning and animation issues when PullDownButton is used in CupertinoNavigationBar's trailing widget on Flutter 3.35.0+.

Fixes #74

## Videos
<table>
  <tr>
    <td align="center">
      <strong>Before</strong><br>
      <video src="https://github.com/user-attachments/assets/e959b29d-f63a-4136-8b25-ae3f7d9f8d15" width="300" controls></video>
    </td>
    <td align="center">
      <strong>After</strong><br>
      <video src="https://github.com/user-attachments/assets/60ea8a3d-1dff-4f4c-a18b-0e8378d54857" width="300" controls></video>
    </td>
  </tr>
</table>

## Root Cause

Flutter 3.35.0 introduced a regression (via PR flutter/flutter#168866) where CupertinoNavigationBar wraps its children (leading, middle, trailing) with a new MediaQueryData that only sets the textScaler field:

```dart
// Broken in Flutter 3.35.0
MediaQuery(
  data: MediaQueryData(textScaler: ...),  // All other fields default!
  child: userTrailing,
)
```

This causes all other MediaQueryData fields to reset to defaults:
- `size` → `Size(0, 0)` 
- `padding` → `EdgeInsets.zero` 
- `devicePixelRatio` → `1.0` 

PullDownButton's positioning logic relies on `MediaQuery.of(context).size` to calculate screen bounds, which now returns invalid dimensions when the button is inside CupertinoNavigationBar's trailing widget.

## Solution

Pass the navigator overlay's context for MediaQuery lookups instead of using the button's context. The overlay always has complete MediaQueryData with correct screen dimensions.

**Changes:**
- Add optional `mediaQueryContext` parameter to `getRect()` in `extensions.dart`
- Add optional `overlayContext` parameter to `animationAlignment()` in `route.dart`
- Update both call sites in `pull_down_button.dart` to pass `navigator.overlay!.context`
