### PR TITLE
Fix: Execute menu item callbacks even when widget is unmounted

### DIFF
--- a/lib/src/pull_down_button.dart
+++ b/lib/src/pull_down_button.dart
@@ -427,12 +427,13 @@ class _PullDownButtonState extends State<PullDownButton> {
       routeSettings: widget.routeSettings,
     );
 
-    if (!mounted) {
-      return;
+    // Update state only if widget is still mounted
+    if (mounted) {
+      setState(() => state = PullDownButtonAnimationState.closed);
     }
 
-    setState(() => state = PullDownButtonAnimationState.closed);
-
+    // Execute action callback even if widget is unmounted
+    // The user performed an action and it should be honored
     if (action != null) {
       action.call();
     } else {


### PR DESCRIPTION
Fixes #77

When `PullDownButton` widget becomes unmounted during menu dismissal, the previous code would skip executing the user's selected action callback.

This PR separates the mounted check: Skip `setState` only if unmounted (prevents crash), and always execute the action callback (honors user intent).

## Videos
<table>
  <tr>
    <td align="center">
      <strong>Before</strong><br>
      <video src="https://github.com/user-attachments/assets/338a4c21-c56f-4cfb-a3c5-fa623388dba3" width="300" controls></video>
    </td>
    <td align="center">
      <strong>After</strong><br>
      <video src="https://github.com/user-attachments/assets/76ee8a46-ddf6-4f87-8bad-5fd23247ef9c" width="300" controls></video>
    </td>
  </tr>
</table>









## Changes
- Move mounted check to only protect `setState`
- Always execute action callback, regardless of mounted state
- Add comments explaining the rationale

Fixes issue where menu selections were ignored on first app launch or after hot restart.